### PR TITLE
Add basic controllers for CRM API

### DIFF
--- a/CrmWS/CRM.API/Controllers/ActivitiesController.cs
+++ b/CrmWS/CRM.API/Controllers/ActivitiesController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using CRM.Business.Interfaces;
+using CRM.Core.Models;
+
+namespace CRM.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ActivitiesController : ControllerBase
+    {
+        private readonly IActivityService _activityService;
+
+        public ActivitiesController(IActivityService activityService)
+        {
+            _activityService = activityService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Activity>>> GetAll()
+        {
+            var activities = await _activityService.GetAllActivitiesAsync();
+            return Ok(activities);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Activity>> GetById(int id)
+        {
+            var activity = await _activityService.GetActivityByIdAsync(id);
+            if (activity == null) return NotFound();
+            return Ok(activity);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Activity>> Create(Activity activity)
+        {
+            var created = await _activityService.CreateActivityAsync(activity);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, Activity activity)
+        {
+            if (id != activity.Id) return BadRequest();
+            var updated = await _activityService.UpdateActivityAsync(activity);
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _activityService.DeleteActivityAsync(id);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/CrmWS/CRM.API/Controllers/AuthController.cs
+++ b/CrmWS/CRM.API/Controllers/AuthController.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Mvc;
+using CRM.Business.Interfaces;
+using CRM.Core.Models;
+
+namespace CRM.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private readonly IAuthService _authService;
+
+        public AuthController(IAuthService authService)
+        {
+            _authService = authService;
+        }
+
+        [HttpPost("login")]
+        public async Task<ActionResult<string>> Login([FromBody] LoginRequest request)
+        {
+            var token = await _authService.LoginAsync(request.Email, request.Password);
+            return Ok(token);
+        }
+
+        [HttpPost("register")]
+        public async Task<ActionResult<User>> Register([FromBody] RegisterRequest request)
+        {
+            var user = new User
+            {
+                FirstName = request.FirstName,
+                LastName = request.LastName,
+                Email = request.Email
+            };
+
+            var createdUser = await _authService.RegisterAsync(user, request.Password);
+            return Ok(createdUser);
+        }
+
+        [HttpPost("change-password")]
+        public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequest request)
+        {
+            var result = await _authService.ChangePasswordAsync(request.UserId, request.CurrentPassword, request.NewPassword);
+            if (!result) return BadRequest();
+            return NoContent();
+        }
+
+        public record LoginRequest(string Email, string Password);
+        public record RegisterRequest(string FirstName, string LastName, string Email, string Password);
+        public record ChangePasswordRequest(int UserId, string CurrentPassword, string NewPassword);
+    }
+}

--- a/CrmWS/CRM.API/Controllers/CompaniesController.cs
+++ b/CrmWS/CRM.API/Controllers/CompaniesController.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Mvc;
+using CRM.Business.Interfaces;
+using CRM.Core.Models;
+
+namespace CRM.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CompaniesController : ControllerBase
+    {
+        private readonly ICompanyService _companyService;
+
+        public CompaniesController(ICompanyService companyService)
+        {
+            _companyService = companyService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Company>>> GetAll()
+        {
+            var companies = await _companyService.GetAllCompaniesAsync();
+            return Ok(companies);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Company>> GetById(int id)
+        {
+            var company = await _companyService.GetCompanyByIdAsync(id);
+            if (company == null) return NotFound();
+            return Ok(company);
+        }
+
+        [HttpGet("search")]
+        public async Task<ActionResult<IEnumerable<Company>>> Search([FromQuery] string name)
+        {
+            var companies = await _companyService.SearchCompaniesByNameAsync(name);
+            return Ok(companies);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Company>> Create(Company company)
+        {
+            var created = await _companyService.CreateCompanyAsync(company);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, Company company)
+        {
+            if (id != company.Id) return BadRequest();
+            var updated = await _companyService.UpdateCompanyAsync(company);
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _companyService.DeleteCompanyAsync(id);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/CrmWS/CRM.API/Controllers/ContactsController.cs
+++ b/CrmWS/CRM.API/Controllers/ContactsController.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Mvc;
+using CRM.Business.Interfaces;
+using CRM.Core.Models;
+
+namespace CRM.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ContactsController : ControllerBase
+    {
+        private readonly IContactService _contactService;
+
+        public ContactsController(IContactService contactService)
+        {
+            _contactService = contactService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Contact>>> GetAll()
+        {
+            var contacts = await _contactService.GetAllContactsAsync();
+            return Ok(contacts);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Contact>> GetById(int id)
+        {
+            var contact = await _contactService.GetContactByIdAsync(id);
+            if (contact == null) return NotFound();
+            return Ok(contact);
+        }
+
+        [HttpGet("company/{companyId}")]
+        public async Task<ActionResult<IEnumerable<Contact>>> GetByCompany(int companyId)
+        {
+            var contacts = await _contactService.GetContactsByCompanyAsync(companyId);
+            return Ok(contacts);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Contact>> Create(Contact contact)
+        {
+            var created = await _contactService.CreateContactAsync(contact);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, Contact contact)
+        {
+            if (id != contact.Id) return BadRequest();
+            var updated = await _contactService.UpdateContactAsync(contact);
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _contactService.DeleteContactAsync(id);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/CrmWS/CRM.API/Controllers/OpportunitiesController.cs
+++ b/CrmWS/CRM.API/Controllers/OpportunitiesController.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Mvc;
+using CRM.Business.Interfaces;
+using CRM.Core.Models;
+
+namespace CRM.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class OpportunitiesController : ControllerBase
+    {
+        private readonly IOpportunityService _opportunityService;
+
+        public OpportunitiesController(IOpportunityService opportunityService)
+        {
+            _opportunityService = opportunityService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Opportunity>>> GetAll()
+        {
+            var opportunities = await _opportunityService.GetAllOpportunitiesAsync();
+            return Ok(opportunities);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Opportunity>> GetById(int id)
+        {
+            var opportunity = await _opportunityService.GetOpportunityByIdAsync(id);
+            if (opportunity == null) return NotFound();
+            return Ok(opportunity);
+        }
+
+        [HttpGet("user/{userId}")]
+        public async Task<ActionResult<IEnumerable<Opportunity>>> GetByUser(int userId)
+        {
+            var opportunities = await _opportunityService.GetOpportunitiesByUserAsync(userId);
+            return Ok(opportunities);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Opportunity>> Create(Opportunity opportunity)
+        {
+            var created = await _opportunityService.CreateOpportunityAsync(opportunity);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, Opportunity opportunity)
+        {
+            if (id != opportunity.Id) return BadRequest();
+            var updated = await _opportunityService.UpdateOpportunityAsync(opportunity);
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _opportunityService.DeleteOpportunityAsync(id);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/CrmWS/CRM.API/Controllers/TasksController.cs
+++ b/CrmWS/CRM.API/Controllers/TasksController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc;
+using CRM.Business.Interfaces;
+using CRM.Core.Models;
+
+namespace CRM.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TasksController : ControllerBase
+    {
+        private readonly ICrmTaskService _taskService;
+
+        public TasksController(ICrmTaskService taskService)
+        {
+            _taskService = taskService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<CrmTask>>> GetAll()
+        {
+            var tasks = await _taskService.GetAllTasksAsync();
+            return Ok(tasks);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<CrmTask>> GetById(int id)
+        {
+            var task = await _taskService.GetTaskByIdAsync(id);
+            if (task == null) return NotFound();
+            return Ok(task);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<CrmTask>> Create(CrmTask task)
+        {
+            var created = await _taskService.CreateTaskAsync(task);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, CrmTask task)
+        {
+            if (id != task.Id) return BadRequest();
+            var updated = await _taskService.UpdateTaskAsync(task);
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _taskService.DeleteTaskAsync(id);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+
+        [HttpPost("{id}/complete")]
+        public async Task<IActionResult> Complete(int id)
+        {
+            var result = await _taskService.CompleteTaskAsync(id);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/CrmWS/CRM.API/Controllers/UsersController.cs
+++ b/CrmWS/CRM.API/Controllers/UsersController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using CRM.Business.Interfaces;
+using CRM.Core.Models;
+
+namespace CRM.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UsersController : ControllerBase
+    {
+        private readonly IUserService _userService;
+
+        public UsersController(IUserService userService)
+        {
+            _userService = userService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<User>>> GetAll()
+        {
+            var users = await _userService.GetAllUsersAsync();
+            return Ok(users);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<User>> GetById(int id)
+        {
+            var user = await _userService.GetUserByIdAsync(id);
+            if (user == null) return NotFound();
+            return Ok(user);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<User>> Create(User user)
+        {
+            var created = await _userService.CreateUserAsync(user);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(int id, User user)
+        {
+            if (id != user.Id) return BadRequest();
+            var updated = await _userService.UpdateUserAsync(user);
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _userService.DeleteUserAsync(id);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add authentication controller with login, register, and password change endpoints
- create CRUD controllers for users, companies, contacts, opportunities, tasks (with completion), and activities

## Testing
- `dotnet build CrmWS/CrmWS.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66badd7888323b7f9bb386db3eb86