### PR TITLE
Fix seeding timestamps and configure revenue precision

### DIFF
--- a/CrmWS/CRM.API/Program.cs
+++ b/CrmWS/CRM.API/Program.cs
@@ -136,7 +136,10 @@ if (app.Environment.IsDevelopment())
     });
 }
 
-app.UseHttpsRedirection();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 
 app.UseCors("AllowAll");
 

--- a/CrmWS/CRM.Core/Models/BaseEntity.cs
+++ b/CrmWS/CRM.Core/Models/BaseEntity.cs
@@ -6,7 +6,7 @@ namespace CRM.Core.Models
     {
         [Key]
         public int Id { get; set; }
-        public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public DateTime CreatedAt { get; set; }
         public DateTime? UpdatedAt { get; set; }
         public string CreatedBy { get; set; } = string.Empty;
         public string? UpdatedBy { get; set; }

--- a/CrmWS/CRM.DataAccess/CrmDbContext.cs
+++ b/CrmWS/CRM.DataAccess/CrmDbContext.cs
@@ -164,6 +164,10 @@ namespace CRM.DataAccess
             modelBuilder.Entity<Company>()
                 .HasIndex(c => c.Name);
 
+            modelBuilder.Entity<Company>()
+                .Property(c => c.AnnualRevenue)
+                .HasColumnType("decimal(18,2)");
+
             modelBuilder.Entity<Contact>()
                 .HasIndex(c => c.Email);
 


### PR DESCRIPTION
## Summary
- remove dynamic default timestamp that broke migrations
- specify decimal precision for company annual revenue
- only enforce HTTPS redirection outside development

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c672e8b0d88323a826ff9d502f2c29